### PR TITLE
Feature/bfp init calc hr

### DIFF
--- a/modules/lib_aec/src/aec_impl.c
+++ b/modules/lib_aec/src/aec_impl.c
@@ -110,8 +110,7 @@ void aec_calc_time_domain_ema_energy(
         return;
     }
     bfp_s32_t input_chunk;
-    bfp_s32_init(&input_chunk, &input->data[start_offset], input->exp, length, 0);
-    input_chunk.hr = input->hr;
+    bfp_s32_init(&input_chunk, &input->data[start_offset], input->exp, length, 1);
     float_s64_t dot64 = bfp_s32_dot(&input_chunk, &input_chunk);
     float_s32_t dot = float_s64_to_float_s32(dot64);
     *ema_energy = float_s32_ema(*ema_energy, dot, conf->aec_core_conf.ema_alpha_q30);
@@ -229,13 +228,11 @@ void aec_calc_coherence(
     coherence_mu_params_t *coh_mu_state_ptr = &state->shared_state->coh_mu_state[ch];
     //We need y_hat[240:480] and y[240:480]
     bfp_s32_t y_hat_subset;
-    bfp_s32_init(&y_hat_subset, &state->y_hat[ch].data[AEC_FRAME_ADVANCE], state->y_hat[ch].exp, AEC_FRAME_ADVANCE, 0);
-    y_hat_subset.hr = state->y_hat[ch].hr;
+    bfp_s32_init(&y_hat_subset, &state->y_hat[ch].data[AEC_FRAME_ADVANCE], state->y_hat[ch].exp, AEC_FRAME_ADVANCE, 1);
 
     //y[240:480] is prev_y[0:240]. Create a temporary bfp_s32_t to point to prev_y[0:240]
     bfp_s32_t temp;
-    bfp_s32_init(&temp, state->shared_state->prev_y[ch].data, state->shared_state->prev_y[ch].exp, AEC_FRAME_ADVANCE, 0);
-    temp.hr = state->shared_state->prev_y[ch].hr;
+    bfp_s32_init(&temp, state->shared_state->prev_y[ch].data, state->shared_state->prev_y[ch].exp, AEC_FRAME_ADVANCE, 1);
 
     aec_priv_calc_coherence(coh_mu_state_ptr, &temp, &y_hat_subset, &state->shared_state->config_params);
 }

--- a/modules/lib_aec/src/aec_l2_impl.c
+++ b/modules/lib_aec/src/aec_l2_impl.c
@@ -37,7 +37,7 @@ void aec_l2_calc_Error_and_Y_hat(
         for(unsigned ph=0; ph<phases; ph++) {
             //create input chunks
             bfp_complex_s32_t X_chunk, H_hat_chunk;
-            bfp_complex_s32_init(&X_chunk, &X_fifo[ph].data[start_offset], X_fifo[ph].exp, length, 0);
+            bfp_complex_s32_init(&X_chunk, &X_fifo[ph].data[start_offset], X_fifo[ph].exp, length, 0); //Not recalculating headroom here to make sure outputs are bitexact irrespective of the length this function is called for.
             X_chunk.hr = X_fifo[ph].hr;
             bfp_complex_s32_init(&H_hat_chunk, &H_hat[ph].data[start_offset], H_hat[ph].exp, length, 0);
             H_hat_chunk.hr = H_hat[ph].hr;

--- a/modules/lib_aec/src/aec_priv_impl.c
+++ b/modules/lib_aec/src/aec_priv_impl.c
@@ -535,19 +535,17 @@ void aec_priv_bfp_complex_s32_recalc_energy_one_bin(
     bfp_complex_s32_t temp_in;
 
     for(unsigned i=0; i<num_phases-1; i++) {
-        bfp_complex_s32_init(&temp_in, &X_fifo[i].data[recalc_bin], X_fifo[i].exp, 1, 0);
-        temp_in.hr = X_fifo[i].hr;
+        bfp_complex_s32_init(&temp_in, &X_fifo[i].data[recalc_bin], X_fifo[i].exp, 1, 1);
         bfp_complex_s32_squared_mag(&temp_out, &temp_in);
         bfp_s32_add(&sum_out, &sum_out, &temp_out);
     }
-    bfp_complex_s32_init(&temp_in, &X->data[recalc_bin], X->exp, 1, 0);
-    temp_in.hr = X->hr;
+    bfp_complex_s32_init(&temp_in, &X->data[recalc_bin], X->exp, 1, 1);
     
     bfp_complex_s32_squared_mag(&temp_out, &temp_in);
     bfp_s32_add(&sum_out, &sum_out, &temp_out);
     bfp_s32_use_exponent(&sum_out, X_energy->exp);
 
-    //TODO manage headroom mismatch
+    // manage headroom mismatch
     X_energy->data[recalc_bin] = sum_out.data[0];
     if(sum_out.hr < X_energy->hr) {
         X_energy->hr = sum_out.hr;
@@ -756,10 +754,8 @@ void aec_priv_create_output(
     memset(error->data, 0, AEC_FRAME_ADVANCE*sizeof(int32_t));
 
     bfp_s32_t chunks[2];
-    bfp_s32_init(&chunks[0], &error->data[AEC_FRAME_ADVANCE], error->exp, AEC_UNUSED_TAPS_PER_PHASE*2, 0); //240-272 fwd win
-    chunks[0].hr = error->hr;
-    bfp_s32_init(&chunks[1], &error->data[2*AEC_FRAME_ADVANCE], error->exp, AEC_UNUSED_TAPS_PER_PHASE*2, 0); //480-512 flpd win
-    chunks[1].hr = error->hr;
+    bfp_s32_init(&chunks[0], &error->data[AEC_FRAME_ADVANCE], error->exp, AEC_UNUSED_TAPS_PER_PHASE*2, 1); //240-272 fwd win
+    bfp_s32_init(&chunks[1], &error->data[2*AEC_FRAME_ADVANCE], error->exp, AEC_UNUSED_TAPS_PER_PHASE*2, 1); //480-512 flpd win
 
     //window error
     bfp_s32_mul(&chunks[0], &chunks[0], &win);
@@ -781,10 +777,8 @@ void aec_priv_create_output(
 
         //overlap add
         //split output into 2 chunks. chunk[0] with first 32 samples of output. chunk[1] has rest of the 240-32 samples of output
-        bfp_s32_init(&chunks[0], &output->data[0], output->exp, AEC_UNUSED_TAPS_PER_PHASE*2, 0);
-        chunks[0].hr = output->hr;
-        bfp_s32_init(&chunks[1], &output->data[AEC_UNUSED_TAPS_PER_PHASE*2], output->exp, AEC_FRAME_ADVANCE-(AEC_UNUSED_TAPS_PER_PHASE*2), 0);
-        chunks[1].hr = output->hr;
+        bfp_s32_init(&chunks[0], &output->data[0], output->exp, AEC_UNUSED_TAPS_PER_PHASE*2, 1);
+        bfp_s32_init(&chunks[1], &output->data[AEC_UNUSED_TAPS_PER_PHASE*2], output->exp, AEC_FRAME_ADVANCE-(AEC_UNUSED_TAPS_PER_PHASE*2), 1);
 
         //Add previous frame's overlap to first 32 samples of output
         bfp_s32_add(&chunks[0], &chunks[0], overlap);


### PR DESCRIPTION
Issue https://github.com/xmos/sw_avona/issues/285
Calculate headroom as part of bfp_s32_init() and bfp_complex_s32_init() in AEC module for cases where doing so might increase precision